### PR TITLE
Make error messages visible in CI console

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        hash=$(${GITHUB_ACTION_PATH}/list-make-prerequisites.py ${{ inputs.target }} ${{ inputs.flags }} --hash 2>/dev/null)
-        prerequisites=$(${GITHUB_ACTION_PATH}/list-make-prerequisites.py ${{ inputs.target }} ${{ inputs.flags }} 2>/dev/null | xargs)
+        hash=$(${GITHUB_ACTION_PATH}/list-make-prerequisites.py ${{ inputs.target }} ${{ inputs.flags }} --hash)
+        prerequisites=$(${GITHUB_ACTION_PATH}/list-make-prerequisites.py ${{ inputs.target }} ${{ inputs.flags }} | xargs)
         echo "hash=$hash" >> $GITHUB_OUTPUT
         echo "prerequisites=$prerequisites" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR removes the redirection of stderr output to `/dev/null`, ensuring that it appears on the CI console.

This does not interfere with the variable assignment nor piping to `xargs` as only stdout is considered for these.